### PR TITLE
test: ensure no Pascalcase in washroom

### DIFF
--- a/src/test/java/de/derkomischeagilist/AdventureTest.java
+++ b/src/test/java/de/derkomischeagilist/AdventureTest.java
@@ -1,5 +1,6 @@
 package de.derkomischeagilist;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +51,7 @@ public class AdventureTest {
         //When I look at the door
         String actual = adventure.tell("look at door");
         //Then there is shown, that it is a washroom
-        assertThat(actual, containsStringIgnoringCase("washroom"));
+        assertThat(actual, CoreMatchers.containsString("washroom"));
     }
 
     @Test


### PR DESCRIPTION
Just adapted the test, so there is no way PascalCase is ever used in the word washroom in this scenario.